### PR TITLE
Fix resume download

### DIFF
--- a/app/(site)/about/page.tsx
+++ b/app/(site)/about/page.tsx
@@ -36,7 +36,7 @@ export default async function About() {
                   />
 
                   <a
-                    href={`${data.resumeURL}?dl=${data.fullName}_resume`}
+                    href={`${data.resumeURL}?dl=${data.fullName}_resume.pdf`}
                     className="flex items-center justify-center gap-x-2 bg-[#1d1d20] border border-transparent hover:border-zinc-700 rounded-md duration-200 py-2 text-center cursor-cell font-medium"
                   >
                     <BiFile className="text-base" /> Download Resumé


### PR DESCRIPTION
Fixed resume download adding .pdf to the href used to download the resume
Before:
![image](https://github.com/Evavic44/sanity-nextjs-site/assets/104316401/54172558-0646-4a38-bea8-589c17576509)


After:
![image](https://github.com/Evavic44/sanity-nextjs-site/assets/104316401/14ad2535-d7b6-49d8-91e5-8d4d54848737)

